### PR TITLE
created the chainner homebrew tap

### DIFF
--- a/.github/workflows/bump-chainner-cask.yml
+++ b/.github/workflows/bump-chainner-cask.yml
@@ -1,0 +1,18 @@
+name: bump-chainner-cask
+on:
+  schedule:
+    - cron:  '0 8,20 * * *'
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  bump-casks:
+    runs-on: macos-latest
+    steps:
+    - uses: macauley/action-homebrew-bump-cask@v1
+      with:
+        token: ${{secrets.BUMP_CASK_TOKEN}}
+        tap: chaiNNer-org/homebrew-chaiNNer
+        cask: chainner
+        livecheck: true
+        dryrun: false

--- a/Casks/chainner.rb
+++ b/Casks/chainner.rb
@@ -1,0 +1,40 @@
+cask "chainner" do
+  version "0.19.0"
+  # TODO: remove sh256 and url when an arm64 build is available
+  sha256 "d2b2b92fbd5db85ef4980fc86f9a1db04733605693e73abd774469b155be144a"
+
+  url "https://github.com/chaiNNer-org/chaiNNer/releases/download/v#{version}/chaiNNer-#{version}-x64-macos.dmg",
+      verified: "github.com/chaiNNer-org/chaiNNer/"
+  # TODO: enable this block when an arm64 build is available
+  #   on_arm do
+  #     sha256 ""
+  #
+  #     url "https://github.com/chaiNNer-org/chaiNNer/releases/download/v#{version}/chaiNNer-#{version}-arm64-macos.dmg",
+  #         verified: "github.com/chaiNNer-org/chaiNNer/"
+  #   end
+  #   on_intel do
+  #     sha256 "d2b2b92fbd5db85ef4980fc86f9a1db04733605693e73abd774469b155be144a"
+  #
+  #     url "https://github.com/chaiNNer-org/chaiNNer/releases/download/v#{version}/chaiNNer-#{version}-x64-macos.dmg",
+  #         verified: "github.com/chaiNNer-org/chaiNNer/"
+  #   end
+
+  name "chaiNNer"
+  desc "GUI for easy, customizable chaining of image processing tasks"
+  homepage "https://chainner.app/"
+
+  livecheck do
+    url "https://github.com/chaiNNer-org/chaiNNer/releases/latest"
+    strategy :github_latest
+  end
+
+  app "chaiNNer.app"
+
+  zap trash: [
+    "~/Library/Application Support/chaiNNer",
+    "~/Library/Caches/chainner_pip",
+    "~/Library/Logs/chaiNNer",
+    "~/Library/Preferences/com.electron.chainner.plist",
+    "~/Library/Saved Application State/com.electron.chainner.savedState",
+  ]
+end

--- a/README.md
+++ b/README.md
@@ -3,5 +3,5 @@
 Install chaiNNer with:
 
 ```bash
-brew install --cask --no-quarantine chaiNNer-org/chaiNNer/chaiNNer
+brew install --cask --no-quarantine chaiNNer-org/chaiNNer/chainner
 ```


### PR DESCRIPTION
Addresses [chaiNNer/issues/2025](https://github.com/chaiNNer-org/chaiNNer/issues/2025).

You need to add a secret named `BUMP_CASK_TOKEN` to the repo for the workflow to execute without errors.